### PR TITLE
Add Cloud Agent development environment config

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,4 @@
+{
+  "name": "tinylamb",
+  "install": "sudo apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends build-essential cmake ninja-build clang clang-format libstdc++-14-dev postgresql-client curl git ca-certificates"
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a Cloud Agent development environment configuration (`.cursor/environment.json`) for `tinylamb`, a C++20 RDBMS built with CMake.

The environment uses Cursor's default image plus an idempotent `install` step that installs the toolchain and tools the project needs:

- `build-essential` + `libstdc++-14-dev` — C++20 toolchain and the `libstdc++` dev files clang selects (the default image ships `libgcc-14-dev` but not `libstdc++-14-dev`, which otherwise breaks linking with `cannot find -lstdc++`).
- `cmake`, `ninja-build`, `clang` — the build system and compiler used by CI and the README.
- `clang-format` — required by the `clang-format` CI check.
- `postgresql-client` — `psql` for exercising the PostgreSQL-wire `tinylamb_server`.
- `curl`, `git`, `ca-certificates` — for the pinned GoogleSQL / googletest / TPC-H DBGEN downloads CMake performs.

The build downloads its dependencies (pinned GoogleSQL `execute_query` binary with SHA-256 verification, googletest v1.14.0 via `FetchContent`, and the TPC-H DBGEN source) over the network, so no vendored deps are required.

## Validation

- Toolchain chain proven end-to-end on the repo's real code: a clean clang + CMake + Ninja + googletest `FetchContent` build compiled `parser/tokenizer.cpp` and ran `parser/tokenizer_test.cpp` under `ctest` — all 6 cases passed.
- The pinned GoogleSQL frontend binary downloaded (checksum-verified) and executed a real query.
- `install` is idempotent (second run reports `0 added, 0 removed`).

## Note on repository build state

The full project does **not** build at the current `master` (`d37c659`): `CMakeLists.txt` and `README.md` reference roughly 60 source files that are not committed to the repository — the entire `server/` and `benchmark/` directories plus `query/sql_engine.cpp`, `query/googlesql_*.cpp`, several `executor/`, `expression/`, and `plan/` sources. CMake configuration therefore fails before any target can be built. This is a codebase issue independent of the environment; once those sources are committed, the configured environment builds and tests the project with the standard `cmake -S . -B build -G Ninja && cmake --build build -j && ctest --test-dir build` flow.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-773cdbf3-2ab4-4e0c-9923-c17af4783eb7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-773cdbf3-2ab4-4e0c-9923-c17af4783eb7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

